### PR TITLE
Add some screen reader accessibility improvements

### DIFF
--- a/app/src/main/java/com/bnyro/recorder/ui/common/ChipSelector.kt
+++ b/app/src/main/java/com/bnyro/recorder/ui/common/ChipSelector.kt
@@ -15,6 +15,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -31,7 +36,8 @@ fun ChipSelector(
     Text(
         text = title,
         fontWeight = FontWeight.Bold,
-        fontSize = 18.sp
+        fontSize = 18.sp,
+        modifier = Modifier.semantics { heading() }
     )
     Spacer(modifier = Modifier.height(5.dp))
     LazyRow(
@@ -39,7 +45,12 @@ fun ChipSelector(
     ) {
         itemsIndexed(entries) { index, entry ->
             ElevatedFilterChip(
-                modifier = Modifier.padding(end = 10.dp),
+                modifier = Modifier
+                    .padding(end = 10.dp)
+                    .clearAndSetSemantics { // We need to suppress calculated contentDescription that contains word selected or not selected based off of the selected state
+                        contentDescription = entry
+                        selected = selections.contains(values[index])
+                    },
                 label = {
                     Text(entry)
                 },

--- a/app/src/main/java/com/bnyro/recorder/ui/common/FullscreenDialog.kt
+++ b/app/src/main/java/com/bnyro/recorder/ui/common/FullscreenDialog.kt
@@ -11,8 +11,10 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import com.bnyro.recorder.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -35,7 +37,10 @@ fun FullscreenDialog(
                         Text(title)
                     },
                     navigationIcon = {
-                        ClickableIcon(imageVector = Icons.Default.ArrowBack) {
+                        ClickableIcon(
+                            imageVector = Icons.Default.ArrowBack,
+                            contentDescription = stringResource(R.string.back)
+                        ) {
                             onDismissRequest.invoke()
                         }
                     },

--- a/app/src/main/java/com/bnyro/recorder/ui/components/RecordingItem.kt
+++ b/app/src/main/java/com/bnyro/recorder/ui/components/RecordingItem.kt
@@ -73,7 +73,8 @@ fun RecordingItem(recordingFile: DocumentFile) {
                 text = recordingFile.name.orEmpty()
             )
             ClickableIcon(
-                imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow
+                imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
+                contentDescription = stringResource(if (isPlaying) R.string.pause else R.string.play)
             ) {
                 if (!isPlaying && recordingFile.name.orEmpty().endsWith(".mp4")) {
                     showPlayer = true
@@ -88,7 +89,10 @@ fun RecordingItem(recordingFile: DocumentFile) {
                 }
             }
             Box {
-                ClickableIcon(imageVector = Icons.Default.MoreVert) {
+                ClickableIcon(
+                    imageVector = Icons.Default.MoreVert,
+                    contentDescription = stringResource(R.string.options)
+                ) {
                     showDropDown = true
                 }
 

--- a/app/src/main/java/com/bnyro/recorder/ui/screens/RecorderView.kt
+++ b/app/src/main/java/com/bnyro/recorder/ui/screens/RecorderView.kt
@@ -150,7 +150,7 @@ fun RecorderView(
                 Row(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    ClickableIcon(imageVector = Icons.Default.Settings) {
+                    ClickableIcon(imageVector = Icons.Default.Settings, contentDescription = stringResource(R.string.settings)) {
                         showBottomSheet = true
                     }
 
@@ -171,7 +171,11 @@ fun RecorderView(
                                 recordScreenMode -> Icons.Default.Videocam
                                 else -> Icons.Default.Mic
                             },
-                            contentDescription = null
+                            contentDescription = stringResource(if (recorderModel.recorderState == RecorderState.ACTIVE) {
+                                R.string.stop
+                            } else {
+                                R.string.record
+                            })
                         )
                     }
 
@@ -183,7 +187,12 @@ fun RecorderView(
                                 Icons.Default.PlayArrow
                             } else {
                                 Icons.Default.Pause
-                            }
+                            },
+                            contentDescription = stringResource(if (recorderModel.recorderState == RecorderState.PAUSED) {
+                                R.string.resume
+                            } else {
+                                R.string.pause
+                            })
                         ) {
                             if (recorderModel.recorderState == RecorderState.PAUSED) {
                                 recorderModel.resumeRecording()
@@ -193,7 +202,8 @@ fun RecorderView(
                         }
                     } else {
                         ClickableIcon(
-                            imageVector = Icons.Default.VideoLibrary
+                            imageVector = Icons.Default.VideoLibrary,
+                            contentDescription = stringResource(R.string.recordings)
                         ) {
                             showPlayerScreen = true
                         }
@@ -204,7 +214,8 @@ fun RecorderView(
 
                 AnimatedVisibility(recorderModel.recorderState != RecorderState.ACTIVE) {
                     ClickableIcon(
-                        imageVector = if (recordScreenMode) Icons.Default.ExpandMore else Icons.Default.ExpandLess
+                        imageVector = if (recordScreenMode) Icons.Default.ExpandMore else Icons.Default.ExpandLess,
+                        contentDescription = stringResource(if (recordScreenMode) R.string.record_sound else R.string.record_screen)
                     ) {
                         recordScreenMode = !recordScreenMode
                     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,4 +28,9 @@
     <string name="pause">Pause</string>
     <string name="resume">Resume</string>
     <string name="recording_finished">Recording finished</string>
+    <string name="settings">Settings</string>
+    <string name="record">Record</string>
+    <string name="play">Play</string>
+    <string name="options">Options</string>
+    <string name="back">Back</string>
 </resources>


### PR DESCRIPTION
Set content descriptions and other tweaks where it makes sense so the app is usefull for screen reader users. Visually disabled and blind people are likelly to enjoy using modern audio recording app so making it accessible is essential.
Tested with Android accessibility suite / Talkback