### PR TITLE
Add more audio settings

### DIFF
--- a/app/src/main/java/com/bnyro/recorder/enums/AudioChannels.kt
+++ b/app/src/main/java/com/bnyro/recorder/enums/AudioChannels.kt
@@ -1,0 +1,10 @@
+package com.bnyro.recorder.enums
+
+enum class AudioChannels(val value: Int) {
+    MONO(1),
+    STEREO(2);
+
+    companion object {
+        fun fromInt(value: Int) = AudioChannels.values().first { it.value == value }
+    }
+}

--- a/app/src/main/java/com/bnyro/recorder/enums/AudioDeviceSource.kt
+++ b/app/src/main/java/com/bnyro/recorder/enums/AudioDeviceSource.kt
@@ -1,0 +1,14 @@
+package com.bnyro.recorder.enums
+
+import android.media.MediaRecorder
+
+enum class AudioDeviceSource(val value: Int) {
+    DEFAULT(MediaRecorder.AudioSource.DEFAULT),
+    MIC(MediaRecorder.AudioSource.MIC),
+    CAMCORDER(MediaRecorder.AudioSource.CAMCORDER),
+    UNPROCESSED(MediaRecorder.AudioSource.UNPROCESSED);
+
+    companion object {
+        fun fromInt(value: Int) = AudioDeviceSource.values().first { it.value == value }
+    }
+}

--- a/app/src/main/java/com/bnyro/recorder/obj/AudioFormat.kt
+++ b/app/src/main/java/com/bnyro/recorder/obj/AudioFormat.kt
@@ -14,7 +14,7 @@ data class AudioFormat(
     companion object {
         private val m4a = AudioFormat(
             MediaRecorder.OutputFormat.MPEG_4,
-            MediaRecorder.AudioEncoder.AAC,
+            MediaRecorder.AudioEncoder.HE_AAC,
             "M4A",
             "m4a"
         )

--- a/app/src/main/java/com/bnyro/recorder/services/AudioRecorderService.kt
+++ b/app/src/main/java/com/bnyro/recorder/services/AudioRecorderService.kt
@@ -25,6 +25,9 @@ class AudioRecorderService : RecorderService() {
             Preferences.prefs.getInt(Preferences.audioBitrateKey, -1).takeIf { it > 0 }?.let {
                 setAudioEncodingBitRate(it)
             }
+            Preferences.prefs.getInt(Preferences.audioChannelsKey, 1).takeIf { it > 1 }?.let {
+                    setAudioChannels(it)
+            }
 
             setOutputFormat(audioFormat.format)
             setAudioEncoder(audioFormat.codec)

--- a/app/src/main/java/com/bnyro/recorder/services/AudioRecorderService.kt
+++ b/app/src/main/java/com/bnyro/recorder/services/AudioRecorderService.kt
@@ -2,6 +2,8 @@ package com.bnyro.recorder.services
 
 import android.media.MediaRecorder
 import com.bnyro.recorder.R
+import com.bnyro.recorder.enums.AudioChannels
+import com.bnyro.recorder.enums.AudioDeviceSource
 import com.bnyro.recorder.obj.AudioFormat
 import com.bnyro.recorder.util.PlayerHelper
 import com.bnyro.recorder.util.Preferences
@@ -15,7 +17,9 @@ class AudioRecorderService : RecorderService() {
         val audioFormat = AudioFormat.getCurrent()
 
         recorder = PlayerHelper.newRecorder(this).apply {
-            setAudioSource(MediaRecorder.AudioSource.DEFAULT)
+            Preferences.prefs.getInt(Preferences.audioDeviceSourceKey, AudioDeviceSource.DEFAULT.value).let {
+                    setAudioSource(it)
+            }
 
             Preferences.prefs.getInt(Preferences.audioSampleRateKey, -1).takeIf { it > 0 }?.let {
                 setAudioSamplingRate(it)
@@ -25,7 +29,7 @@ class AudioRecorderService : RecorderService() {
             Preferences.prefs.getInt(Preferences.audioBitrateKey, -1).takeIf { it > 0 }?.let {
                 setAudioEncodingBitRate(it)
             }
-            Preferences.prefs.getInt(Preferences.audioChannelsKey, 1).takeIf { it > 1 }?.let {
+            Preferences.prefs.getInt(Preferences.audioChannelsKey, AudioChannels.MONO.value).takeIf { it > AudioChannels.MONO.value }?.let {
                     setAudioChannels(it)
             }
 

--- a/app/src/main/java/com/bnyro/recorder/services/RecorderService.kt
+++ b/app/src/main/java/com/bnyro/recorder/services/RecorderService.kt
@@ -103,6 +103,7 @@ abstract class RecorderService : Service() {
             .setContentTitle(notificationTitle)
             .setSmallIcon(R.drawable.ic_notification)
             .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setSilent(true)
             .setOngoing(recorderState == RecorderState.ACTIVE)
             .addAction(stopAction.build())
             .apply {

--- a/app/src/main/java/com/bnyro/recorder/services/ScreenRecorderService.kt
+++ b/app/src/main/java/com/bnyro/recorder/services/ScreenRecorderService.kt
@@ -75,6 +75,9 @@ class ScreenRecorderService : RecorderService() {
                 Preferences.prefs.getInt(Preferences.audioBitrateKey, -1).takeIf { it > 0 }?.let {
                     setAudioEncodingBitRate(it)
                 }
+                Preferences.prefs.getInt(Preferences.audioChannelsKey, 1).takeIf { it > 1 }?.let {
+                    setAudioChannels(it)
+                }
             }
 
             setOutputFormat(videoFormat.format)

--- a/app/src/main/java/com/bnyro/recorder/services/ScreenRecorderService.kt
+++ b/app/src/main/java/com/bnyro/recorder/services/ScreenRecorderService.kt
@@ -14,6 +14,8 @@ import android.util.Log
 import android.view.Display
 import androidx.activity.result.ActivityResult
 import com.bnyro.recorder.R
+import com.bnyro.recorder.enums.AudioChannels
+import com.bnyro.recorder.enums.AudioDeviceSource
 import com.bnyro.recorder.enums.AudioSource
 import com.bnyro.recorder.enums.VideoFormat
 import com.bnyro.recorder.obj.VideoResolution
@@ -64,7 +66,10 @@ class ScreenRecorderService : RecorderService() {
             setVideoSource(MediaRecorder.VideoSource.SURFACE)
 
             if (audioSource == AudioSource.MICROPHONE) {
-                setAudioSource(MediaRecorder.AudioSource.DEFAULT)
+                Preferences.prefs.getInt(Preferences.audioDeviceSourceKey, AudioDeviceSource.DEFAULT.value).let {
+                    setAudioSource(it)
+                }
+
                 Preferences.prefs.getInt(Preferences.audioSampleRateKey, -1).takeIf {
                     it > 0
                 }?.let {
@@ -75,7 +80,7 @@ class ScreenRecorderService : RecorderService() {
                 Preferences.prefs.getInt(Preferences.audioBitrateKey, -1).takeIf { it > 0 }?.let {
                     setAudioEncodingBitRate(it)
                 }
-                Preferences.prefs.getInt(Preferences.audioChannelsKey, 1).takeIf { it > 1 }?.let {
+                Preferences.prefs.getInt(Preferences.audioChannelsKey, AudioChannels.MONO.value).takeIf { it > AudioChannels.MONO.value }?.let {
                     setAudioChannels(it)
                 }
             }

--- a/app/src/main/java/com/bnyro/recorder/ui/components/SettingsBottomSheet.kt
+++ b/app/src/main/java/com/bnyro/recorder/ui/components/SettingsBottomSheet.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.bnyro.recorder.R
 import com.bnyro.recorder.enums.AudioChannels
+import com.bnyro.recorder.enums.AudioDeviceSource
 import com.bnyro.recorder.enums.AudioSource
 import com.bnyro.recorder.enums.ThemeMode
 import com.bnyro.recorder.enums.VideoFormat
@@ -58,7 +59,12 @@ fun SettingsBottomSheet(
     }
     var audioChannels by remember {
         mutableStateOf(
-            AudioChannels.fromInt(Preferences.prefs.getInt(Preferences.audioChannelsKey, 1))
+            AudioChannels.fromInt(Preferences.prefs.getInt(Preferences.audioChannelsKey, AudioChannels.MONO.value))
+        )
+    }
+    var audioDeviceSource by remember {
+        mutableStateOf(
+            AudioDeviceSource.fromInt(Preferences.prefs.getInt(Preferences.audioDeviceSourceKey, AudioDeviceSource.DEFAULT.value))
         )
     }
     var screenAudioSource by remember {
@@ -169,6 +175,19 @@ fun SettingsBottomSheet(
                             audioChannels = AudioChannels.fromInt(audioChannelsValues[index])
                             Preferences.edit { putInt(Preferences.audioChannelsKey, audioChannelsValues[index]) }
                         }
+                    }
+                }
+                val audioDeviceSourceValues = AudioDeviceSource.values().map { it.value }
+                ChipSelector(
+                    entries = listOf(R.string.default_audio, R.string.microphone, R.string.camcorder, R.string.unprocessed).map {
+                        stringResource(it)
+                    },
+                    values = audioDeviceSourceValues,
+                    selections = listOf(audioDeviceSource.value)
+                ) { index, newValue ->
+                    if (newValue) {
+                    audioDeviceSource = AudioDeviceSource.fromInt(audioDeviceSourceValues[index])
+                    Preferences.edit { putInt(Preferences.audioDeviceSourceKey, audioDeviceSourceValues[index]) }
                     }
                 }
                 Spacer(modifier = Modifier.height(10.dp))

--- a/app/src/main/java/com/bnyro/recorder/ui/components/SettingsBottomSheet.kt
+++ b/app/src/main/java/com/bnyro/recorder/ui/components/SettingsBottomSheet.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.bnyro.recorder.R
+import com.bnyro.recorder.enums.AudioChannels
 import com.bnyro.recorder.enums.AudioSource
 import com.bnyro.recorder.enums.ThemeMode
 import com.bnyro.recorder.enums.VideoFormat
@@ -54,6 +55,11 @@ fun SettingsBottomSheet(
 
     var audioFormat by remember {
         mutableStateOf(AudioFormat.getCurrent())
+    }
+    var audioChannels by remember {
+        mutableStateOf(
+            AudioChannels.fromInt(Preferences.prefs.getInt(Preferences.audioChannelsKey, 1))
+        )
     }
     var screenAudioSource by remember {
         mutableStateOf(
@@ -150,6 +156,20 @@ fun SettingsBottomSheet(
                         title = stringResource(R.string.bitrate),
                         defValue = 192_000
                     )
+                    Spacer(modifier = Modifier.width(10.dp))
+                    val audioChannelsValues = AudioChannels.values().map { it.value }
+                    ChipSelector(
+                        entries = listOf(R.string.mono, R.string.stereo).map {
+                            stringResource(it)
+                        },
+                        values = audioChannelsValues,
+                        selections = listOf(audioChannels.value)
+                    ) { index, newValue ->
+                        if (newValue) {
+                            audioChannels = AudioChannels.fromInt(audioChannelsValues[index])
+                            Preferences.edit { putInt(Preferences.audioChannelsKey, audioChannelsValues[index]) }
+                        }
+                    }
                 }
                 Spacer(modifier = Modifier.height(10.dp))
                 val audioValues = AudioSource.values().map { it.value }

--- a/app/src/main/java/com/bnyro/recorder/util/Preferences.kt
+++ b/app/src/main/java/com/bnyro/recorder/util/Preferences.kt
@@ -13,6 +13,7 @@ object Preferences {
     const val audioSampleRateKey = "audioSampleRate"
     const val audioBitrateKey = "audioBitrate"
     const val audioChannelsKey = "audioChannels"
+    const val audioDeviceSourceKey = "audioDeviceSource"
     const val videoCodecKey = "videoCodec"
     const val videoBitrateKey = "videoBitrate"
     const val themeModeKey = "themeMode"

--- a/app/src/main/java/com/bnyro/recorder/util/Preferences.kt
+++ b/app/src/main/java/com/bnyro/recorder/util/Preferences.kt
@@ -12,6 +12,7 @@ object Preferences {
     const val audioSourceKey = "audioSource"
     const val audioSampleRateKey = "audioSampleRate"
     const val audioBitrateKey = "audioBitrate"
+    const val audioChannelsKey = "audioChannels"
     const val videoCodecKey = "videoCodec"
     const val videoBitrateKey = "videoBitrate"
     const val themeModeKey = "themeMode"


### PR DESCRIPTION
List of changes:
* New: ability to configure audio channels - Mono or Stereo.
* New: ability to change Audio device source - that includes Default, Microphone, Camcorder and Unprocessed. On my device all the sources allow stereo recording, unprocesses uses single microphone only.
* Change: Use High efficiency AAC encoder when MP4 format is selected in settings.
* Change: Avoid playing notification sound when starting the recording.


This fixes #63