### PR TITLE
Fix Exoplayer Memory Leak

### DIFF
--- a/app/src/main/java/com/bnyro/recorder/ui/views/VideoView.kt
+++ b/app/src/main/java/com/bnyro/recorder/ui/views/VideoView.kt
@@ -15,7 +15,8 @@ import com.google.android.exoplayer2.ui.StyledPlayerView
 fun VideoView(videoUri: Uri) {
     val context = LocalContext.current
 
-    val exoPlayer = ExoPlayer.Builder(context)
+    val exoPlayer = remember(context) {
+        ExoPlayer.Builder(context)
         .setUsePlatformDiagnostics(false)
         .build()
         .also { exoPlayer ->
@@ -26,7 +27,7 @@ fun VideoView(videoUri: Uri) {
             exoPlayer.prepare()
             exoPlayer.playWhenReady = true
         }
-
+    }
     DisposableEffect(
         AndroidView(
             modifier = Modifier.fillMaxSize(),


### PR DESCRIPTION
Fixed a bug that caused created multiple ExoPlayer instances during each Screen composition. (Cause the phone to freeze if I keep the video view open for too long)

Its quite hard to see the problem.
Problem becomes more noticeable when using `exoPlayer.play()` which plays the video in background but doesn't update the UI. (obviously because it affects a separate invisible instance of the player)
and also `exoPlayer.stop()` doesn't actually stop the playing video.