### PR TITLE
Fix Exoplayer Memory Leak

### DIFF
--- a/app/src/main/java/com/bnyro/recorder/ui/views/VideoView.kt
+++ b/app/src/main/java/com/bnyro/recorder/ui/views/VideoView.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
@@ -15,7 +16,8 @@ import com.google.android.exoplayer2.ui.StyledPlayerView
 fun VideoView(videoUri: Uri) {
     val context = LocalContext.current
 
-    val exoPlayer = ExoPlayer.Builder(context)
+    val exoPlayer = remember(context) {
+        ExoPlayer.Builder(context)
         .setUsePlatformDiagnostics(false)
         .build()
         .also { exoPlayer ->
@@ -26,7 +28,7 @@ fun VideoView(videoUri: Uri) {
             exoPlayer.prepare()
             exoPlayer.playWhenReady = true
         }
-
+    }
     DisposableEffect(
         AndroidView(
             modifier = Modifier.fillMaxSize(),


### PR DESCRIPTION
Fixed a bug that caused created multiple ExoPlayer instances during each Screen composition. (Cause the phone to freeze if I keep the video view open for too long)

Its quite hard to see the problem.
Problem becomes more noticeable when using `exoPlayer.play()` which plays the video in background but doesn't update the UI. (obviously because it affects a separate invisible instance of the player)
and also `exoPlayer.stop()` doesn't actually stop the playing video.
